### PR TITLE
fix audit/review findings and add config query

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,6 +1,6 @@
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
-use crate::state::{Config, VestingInfo, CONFIG, VESTING_INFO};
+use crate::state::{Config, VestingInfo, CONFIG, VESTING_INFO, ConfigResponse};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
@@ -295,6 +295,7 @@ pub fn try_approve_tollgate(
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::VestingInfo { recipient } => to_binary(&query_vesting_info(deps, recipient)?),
+        QueryMsg::Config {} => to_binary(&query_config(deps)?)
     }
 }
 
@@ -308,6 +309,17 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 fn query_vesting_info(deps: Deps, recipient: String) -> StdResult<VestingInfo> {
     let vesting_info = VESTING_INFO.load(deps.storage, &deps.api.addr_validate(&recipient)?)?;
     Ok(vesting_info)
+}
+
+fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
+    let config: Config = CONFIG.load(deps.storage)?;
+    let resp =  ConfigResponse {
+        master_address: config.master_address.to_string(),
+        denom: config.denom,
+        vesting_start_time: config.vesting_start_time
+    };
+
+    Ok(resp)
 }
 
 /// ## Description

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -20,6 +20,9 @@ pub const SECONDS_PER_PERIOD: u64 = 60u64 * 60u64 * 24u64 * 30u64;
 // Number of periods in each Tollgate.
 pub const PERIODS_PER_TOLL: u64 = 3;
 
+// Denom of vested tokens
+pub const DENOM: &str = "uluna";
+
 /// ## Description
 /// Creates a new contract with the specified parameters packed in the `msg` variable.
 /// Returns a [`Response`] with the specified attributes if the operation was successful,
@@ -47,7 +50,7 @@ pub fn instantiate(
     };
 
     // Check sent vesting asset denom
-    if info.funds.len() != 1 || info.funds[0].denom != msg.denom {
+    if info.funds.len() != 1 || info.funds[0].denom != DENOM {
         return Err(ContractError::MismatchedAssetType {});
     }
     let sent_amount = info.funds[0].amount;
@@ -80,6 +83,10 @@ pub fn instantiate(
             3u64
         };
 
+        if vesting.amount == Uint128::new(0u128) {
+            return Err(ContractError::ZeroVestingAmount { address: vesting.recipient })
+        }
+
         let vesting_info = VestingInfo {
             recipient: deps.api.addr_validate(&vesting.recipient)?,
             active: true,
@@ -103,7 +110,7 @@ pub fn instantiate(
         deps.storage,
         &Config {
             master_address: master_address.clone(),
-            denom: msg.denom,
+            denom: DENOM.to_string(),
             vesting_start_time: env.block.time.seconds(),
         },
     )?;

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -41,10 +41,9 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     // Set `master_address` as specified; otherwise, the instantiator
-    let master_address = if msg.master_address.is_none() {
-        info.sender.to_string()
-    } else {
-        msg.master_address.unwrap()
+    let master_address = match msg.master_address {
+        Some(addr) => deps.api.addr_validate(&addr)?,
+        None => info.sender,
     };
 
     // Check sent vesting asset denom
@@ -103,7 +102,7 @@ pub fn instantiate(
     CONFIG.save(
         deps.storage,
         &Config {
-            master_address: deps.api.addr_validate(&master_address)?,
+            master_address: master_address.clone(),
             denom: msg.denom,
             vesting_start_time: env.block.time.seconds(),
         },

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,9 @@ pub enum ContractError {
     #[error("Duplicated recipients")]
     DuplicatedRecipient {},
 
+    #[error("Vesting amount for address {address:?} is 0")]
+    ZeroVestingAmount {address: String},
+
     #[error("Nothing to be claimed")]
     NoClaimable {},
 

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -8,8 +8,6 @@ use serde::{Deserialize, Serialize};
 pub struct InstantiateMsg {
     /// Master address who can update tollgate / status of all vestings
     pub master_address: Option<String>,
-    /// Specific vesting denom
-    pub denom: String,
     /// A list of vestings
     pub vestings: Vec<Vesting>,
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -47,6 +47,8 @@ pub enum QueryMsg {
         /// Recipient address of a protocol
         recipient: String,
     },
+
+    Config {}
 }
 
 /// ## Description

--- a/src/state.rs
+++ b/src/state.rs
@@ -28,7 +28,7 @@ pub const CONFIG: Item<Config> = Item::new("config");
 //////////////////////////////////////////////////////////////////////
 
 /// ## Description
-/// This structure holds the initial vesting paramters for each protocol.
+/// This structure holds the initial vesting parameters for each protocol.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Vesting {
     /// The address of the recipient protocol to approve the tollgate for
@@ -65,4 +65,4 @@ pub struct VestingInfo {
     pub amount_per_period: Uint128,
 }
 
-pub const VESTING_INFO: Map<&Addr, VestingInfo> = Map::new("loan_info");
+pub const VESTING_INFO: Map<&Addr, VestingInfo> = Map::new("vesting_info");

--- a/src/state.rs
+++ b/src/state.rs
@@ -21,6 +21,18 @@ pub struct Config {
     pub vesting_start_time: u64,
 }
 
+/// ## Description
+/// A custom struct for each query response that returns general contract settings/configs.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ConfigResponse {
+    /// Master address who can update tollgate / status of all vestings
+    pub master_address: String,
+    /// Specific vesting denom
+    pub denom: String,
+    /// Start time of this vesting contract, i.e. contract init time
+    pub vesting_start_time: u64,
+}
+
 pub const CONFIG: Item<Config> = Item::new("config");
 
 //////////////////////////////////////////////////////////////////////

--- a/src/testing/mock_env.rs
+++ b/src/testing/mock_env.rs
@@ -49,7 +49,6 @@ pub fn mock_init() -> (OwnedDeps<MockStorage, MockApi, MockQuerier>, Response) {
 
     let msg = InstantiateMsg {
         master_address: Some("master_address".to_string()),
-        denom: "uluna".to_string(),
         vestings,
     };
 
@@ -104,7 +103,6 @@ pub fn mock_full_init() -> (OwnedDeps<MockStorage, MockApi, MockQuerier>, Respon
 
     let msg = InstantiateMsg {
         master_address: Some("master_address".to_string()),
-        denom: "uluna".to_string(),
         vestings,
     };
 

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -142,7 +142,6 @@ pub fn test_fail_init() {
 
     let msg = InstantiateMsg {
         master_address: Some("master_address".to_string()),
-        denom: "uluna".to_string(),
         vestings,
     };
 
@@ -156,24 +155,43 @@ pub fn test_fail_init() {
 
     let vestings = vec![
         Vesting {
-            recipient: "recipient1".to_string(),
+            recipient: "recipient3".to_string(),
             amount: Uint128::from(300_000_000_001u128),
         },
         Vesting {
-            recipient: "recipient1".to_string(),
+            recipient: "recipient3".to_string(),
             amount: Uint128::from(300_000_000_000u128),
         },
     ];
 
     let msg = InstantiateMsg {
         master_address: Some("master_address".to_string()),
-        denom: "uluna".to_string(),
         vestings,
     };
 
     let info = mock_info("addr0000", &[coin(600_000_000_001u128, "uluna")]);
     let res = instantiate(deps.as_mut(), mock_env_time(0), info, msg).unwrap_err();
     assert_eq!(res, ContractError::DuplicatedRecipient {});
+
+    let vestings = vec![
+        Vesting {
+            recipient: "recipient4".to_string(),
+            amount: Uint128::from(300_000_000_001u128),
+        },
+        Vesting {
+            recipient: "recipient5".to_string(),
+            amount: Uint128::from(0u128),
+        },
+    ];
+
+    let msg = InstantiateMsg {
+        master_address: Some("master_address".to_string()),
+        vestings,
+    };
+
+    let info = mock_info("addr0000", &[coin(300_000_000_001u128, "uluna")]);
+    let res = instantiate(deps.as_mut(), mock_env_time(0), info, msg).unwrap_err();
+    assert_eq!(res, ContractError::ZeroVestingAmount {address: "recipient5".to_string()});
 }
 
 #[test]


### PR DESCRIPTION
## Additions

1) Config Query

Add a `Config` query to `QueryMsgs`
## Fixes

1) Define expected vesting token denom as constant

Instead of passing in the denom of the tokens to be vested as a parameter in `InstantiateMsg`, we explicitly define this as a constant (`uluna`) in the contract.

2) `master_address` validation in `instantiate

Slightly alter implementation to only validate `master_address` when using the value passed in from `InstantiateMsg` and not `info.sender` (which is already of validated `Addr`). Also move the validation to beginning of function for clarity.

3) Add check for zero `vesting.amount`

This should help prevent typos and potential errors when creating the `InstantiateMsg` and deploying the contract overall

4) Spelling error fixes

Fixes minor comment typos and corrected `VESTING_INFO` map namespace from `loan_info` to `vesting_info`

